### PR TITLE
unet-cli: refactor

### DIFF
--- a/scripts/unet-cli
+++ b/scripts/unet-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env ucode
 
-let fs = require("fs");
+import { access, basename, dirname, mkstemp, open, writefile } from 'fs';
 
 function assert(cond, message) {
 	if (!cond) {
@@ -12,9 +12,9 @@ function assert(cond, message) {
 }
 
 let script_dir = sourcepath(0, true);
-if (fs.basename(script_dir) == "scripts") {
-	unet_tool = `${fs.dirname(script_dir)}/unet-tool`;
-	assert(fs.access(unet_tool, "x"), "unet-tool missing");
+if (basename(script_dir) == "scripts") {
+	unet_tool = `${dirname(script_dir)}/unet-tool`;
+	assert(access(unet_tool, "x"), "unet-tool missing");
 } else {
 	unet_tool = "unet-tool";
 }
@@ -28,7 +28,7 @@ defaults = {
 };
 
 const usage_message = `
-Usage: ${fs.basename(sourcepath())} [<flags>] <file> <command> [<args>] [<option>=<value> ...]
+Usage: ${basename(sourcepath())} [<flags>] <file> <command> [<args>] [<option>=<value> ...]
 
      Commands:
       - create:					Create a new network file
@@ -247,7 +247,7 @@ function sync_ssh_host(host) {
 	let domain = args.domain ?? "unet";
 
 	if (!auth_key) {
-		let fh = fs.mkstemp();
+		let fh = mkstemp();
 		system(`${unet_tool} -q -P -K ${file}.key >&${fh.fileno()}`);
 		fh.seek();
 		auth_key = fh.read("line");
@@ -259,7 +259,7 @@ function sync_ssh_host(host) {
 		}
 	}
 
-	let fh = fs.mkstemp();
+	let fh = mkstemp();
 	fh.write(`INTERFACE='${interface}'\n`);
 	fh.write(`CONNECT='${connect}'\n`);
 	fh.write(`AUTH_KEY='${auth_key}'\n`);
@@ -269,7 +269,7 @@ function sync_ssh_host(host) {
 	fh.flush();
 	fh.seek();
 
-	fh2 = fs.mkstemp();
+	fh2 = mkstemp();
 	system(`ssh ${host} sh <&${fh.fileno()} >&${fh2.fileno()}`);
 	fh.close();
 
@@ -327,7 +327,7 @@ if (command == "create") {
 		services: {}
 	};
 } else {
-	fh = fs.open(file);
+	fh = open(file);
 	assert(fh, `Could not open input file ${file}`);
 
 	try {
@@ -340,7 +340,7 @@ if (command == "create") {
 if (command == "create") {
 	for (key, val in defaults)
 		args[key] ??= `${val}`;
-	if (!fs.access(`${file}.key`))
+	if (!access(`${file}.key`))
 		system(`${unet_tool} -G > ${file}.key`);
 }
 
@@ -404,4 +404,4 @@ net_data_json = sprintf("%.J\n", net_data);
 if (print_only)
 	print(net_data_json);
 else
-	fs.writefile(file, net_data_json);
+	writefile(file, net_data_json);

--- a/scripts/unet-cli
+++ b/scripts/unet-cli
@@ -2,13 +2,19 @@
 
 let fs = require("fs");
 
-let script_dir = sourcepath(0, true);
-if (fs.basename(script_dir) == "scripts") {
-	unet_tool = fs.dirname(script_dir) + "/unet-tool";
-	if (!fs.access(unet_tool, "x")) {
-		warn("unet-tool missing\n");
+function assert(cond, message) {
+	if (!cond) {
+		warn(message, "\n");
 		exit(1);
 	}
+
+	return true;
+}
+
+let script_dir = sourcepath(0, true);
+if (fs.basename(script_dir) == "scripts") {
+	unet_tool = `${fs.dirname(script_dir)}/unet-tool`;
+	assert(fs.access(unet_tool, "x"), "unet-tool missing");
 } else {
 	unet_tool = "unet-tool";
 }
@@ -21,55 +27,59 @@ defaults = {
 	keepalive: 10,
 };
 
+const usage_message = `
+Usage: ${fs.basename(sourcepath())} [<flags>] <file> <command> [<args>] [<option>=<value> ...]
+
+     Commands:
+      - create:					Create a new network file
+      - set-config:					Change network config parameters
+      - add-host <name>:				Add a host
+      - add-ssh-host <name> <host>:			Add a remote OpenWrt host via SSH
+     						(<host> can contain SSH options as well)
+      - set-host <name>:				Change host settings
+      - set-ssh-host <name> <host>:			Update local and remote host settings
+      - add-service <name>:				Add a service
+      - set-service <name>:				Change service settings
+      - sign						Sign network data
+
+     Flags:
+      -p:						Print modified JSON instead of updating file
+
+     Options:
+      - config options (create, set-config):
+     	port=<val>				set tunnel port (default: ${defaults.port})
+     	pex_port=<val>				set peer-exchange port (default: ${defaults.pex_port})
+     	keepalive=<val>				set keepalive interval (seconds, 0: off, default: ${defaults.keepalive})
+      host options (add-host, add-ssh-host, set-host):
+     	key=<val>				set host public key (required for add-host)
+     	port=<val>				set host tunnel port number
+     	groups=[+|-]<val>[,<val>...]		set/add/remove groups that the host is a member of
+     	ipaddr=[+|-]<val>[,<val>...]		set/add/remove host ip addresses
+     	subnet=[+|-]<val>[,<val>...]		set/add/remove host announced subnets
+     	endpoint=<val>				set host endpoint address
+     	gateway=<name>				set host gateway (using name of other host)
+      ssh host options (add-ssh-host, set-ssh-host)
+     	auth_key=<key>				use <key> as public auth key on the remote host
+     	priv_key=<key>				use <key> as private host key on the remote host (default: generate a new key)
+     	interface=<name>			use <name> as interface in /etc/config/network on the remote host
+     	domain=<name>				use <name> as hosts file domain on the remote host (default: unet)
+     	connect=<val>[,<val>...]		set IP addresses that the host will contact for network updates
+     	tunnels=<ifname>:<service>[,...]	set active tunnel devices
+      service options (add-service, set-service):
+     	type=<val>				set service type (required for add-service)
+     	members=[+|-]<val>[,<val>...]		set/add/remove service member hosts/groups
+      vxlan service options (add-service, set-service):
+     	id=<val>				set VXLAN ID
+     	port=<val>				set VXLAN port
+     	mtu=<val>				set VXLAN device MTU
+     	forward_ports=[+|-]<val>[,<val>...]	set members allowed to receive broadcast/multicast/unknown-unicast
+      sign options:
+     	upload=<ip>[,<ip>...]			upload signed file to hosts
+
+`;
+
 function usage() {
-	warn("Usage: ",fs.basename(sourcepath())," [<flags>] <file> <command> [<args>] [<option>=<value> ...]\n",
-	     "\n",
-	     "Commands:\n",
-	     " - create:					Create a new network file\n",
-	     " - set-config:					Change network config parameters\n",
-	     " - add-host <name>:				Add a host\n",
-	     " - add-ssh-host <name> <host>:			Add a remote OpenWrt host via SSH\n",
-	     "						(<host> can contain SSH options as well)\n",
-	     " - set-host <name>:				Change host settings\n",
-	     " - set-ssh-host <name> <host>:			Update local and remote host settings\n",
-	     " - add-service <name>:				Add a service\n",
-	     " - set-service <name>:				Change service settings\n",
-	     " - sign						Sign network data\n",
-	     "\n",
-	     "Flags:\n",
-	     " -p:						Print modified JSON instead of updating file\n",
-	     "\n",
-	     "Options:\n",
-	     " - config options (create, set-config):\n",
-	     "	port=<val>				set tunnel port (default: ", defaults.port, ")\n",
-	     "	pex_port=<val>				set peer-exchange port (default: ", defaults.pex_port, ")\n",
-	     "	keepalive=<val>				set keepalive interval (seconds, 0: off, default: ", defaults.keepalive,")\n",
-	     " host options (add-host, add-ssh-host, set-host):\n",
-	     "	key=<val>				set host public key (required for add-host)\n",
-	     "	port=<val>				set host tunnel port number\n",
-	     "	groups=[+|-]<val>[,<val>...]		set/add/remove groups that the host is a member of\n",
-	     "	ipaddr=[+|-]<val>[,<val>...]		set/add/remove host ip addresses\n",
-	     "	subnet=[+|-]<val>[,<val>...]		set/add/remove host announced subnets\n",
-	     "	endpoint=<val>				set host endpoint address\n",
-	     "	gateway=<name>				set host gateway (using name of other host)\n",
-	     " ssh host options (add-ssh-host, set-ssh-host)\n",
-	     "	auth_key=<key>				use <key> as public auth key on the remote host\n",
-	     "	priv_key=<key>				use <key> as private host key on the remote host (default: generate a new key)\n",
-	     "	interface=<name>			use <name> as interface in /etc/config/network on the remote host\n",
-	     "	domain=<name>				use <name> as hosts file domain on the remote host (default: unet)\n",
-	     "	connect=<val>[,<val>...]		set IP addresses that the host will contact for network updates\n",
-	     "	tunnels=<ifname>:<service>[,...]	set active tunnel devices\n",
-	     " service options (add-service, set-service):\n",
-	     "	type=<val>				set service type (required for add-service)\n",
-	     "	members=[+|-]<val>[,<val>...]		set/add/remove service member hosts/groups\n",
-	     " vxlan service options (add-service, set-service):\n",
-	     "	id=<val>				set VXLAN ID\n",
-	     "	port=<val>				set VXLAN port\n",
-	     "	mtu=<val>				set VXLAN device MTU\n",
-	     "	forward_ports=[+|-]<val>[,<val>...]	set members allowed to receive broadcast/multicast/unknown-unicast\n",
-	     " sign options:\n",
-	     "	upload=<ip>[,<ip>...]			upload signed file to hosts\n",
-	     "\n");
+	warn(usage_message);
 	return 1;
 }
 
@@ -120,7 +130,7 @@ service_field_types = {
 	},
 };
 
-ssh_script = '
+ssh_script = `
 
 set_list() {
 	local field="$1"
@@ -168,7 +178,7 @@ set_interface_attrs
 uci commit
 reload_config
 ifup $INTERFACE
-';
+`;
 
 args = {};
 print_only = false;
@@ -176,17 +186,14 @@ print_only = false;
 function fetch_args() {
 	for (arg in ARGV) {
 		vals = match(arg, /^(.[[:alnum:]_-]*)=(.*)$/);
-		if (!vals) {
-			warn("Invalid argument: ", arg, "\n");
-			exit(1);
-		}
+		assert(vals, `Invalid argument: ${arg}`);
 		args[vals[1]] = vals[2]
 	}
 }
 
 function set_field(typename, object, name, val) {
 	if (!field_types[typename]) {
-		warn("Invalid type ", type, "\n");
+		warn(`Invalid type ${type}\n`);
 		return;
 	}
 
@@ -241,7 +248,7 @@ function sync_ssh_host(host) {
 
 	if (!auth_key) {
 		let fh = fs.mkstemp();
-		system(unet_tool + " -q -P -K " + file + ".key >&" + fh.fileno());
+		system(`${unet_tool} -q -P -K ${file}.key >&${fh.fileno()}`);
 		fh.seek();
 		auth_key = fh.read("line");
 		fh.close();
@@ -253,17 +260,17 @@ function sync_ssh_host(host) {
 	}
 
 	let fh = fs.mkstemp();
-	fh.write("INTERFACE='" + interface + "'\n");
-	fh.write("CONNECT='" + connect + "'\n");
-	fh.write("AUTH_KEY='" + auth_key + "'\n");
-	fh.write("TUNNELS='" + tunnels + "'\n");
-	fh.write("DOMAIN='" + domain + "'\n");
+	fh.write(`INTERFACE='${interface}'\n`);
+	fh.write(`CONNECT='${connect}'\n`);
+	fh.write(`AUTH_KEY='${auth_key}'\n`);
+	fh.write(`TUNNELS='${tunnels}'\n`);
+	fh.write(`DOMAIN='${domain}'\n`);
 	fh.write(ssh_script);
 	fh.flush();
 	fh.seek();
 
 	fh2 = fs.mkstemp();
-	system(sprintf("ssh "+host+" sh <&%d >&%d", fh.fileno(), fh2.fileno()));
+	system(`ssh ${host} sh <&${fh.fileno()} >&${fh2.fileno()}`);
 	fh.close();
 
 	data = {};
@@ -271,18 +278,12 @@ function sync_ssh_host(host) {
 	fh2.seek();
 	while (line = fh2.read("line")) {
 		let vals = match(line, /^(.[[:alnum:]_-]*)=(.*)\n$/);
-		if (!vals) {
-			warn("Invalid argument: ", arg, "\n");
-			exit(1);
-		}
+		assert(vals, `Invalid argument: ${arg}`);
 		data[vals[1]] = vals[2]
 	}
 	fh2.close();
 
-	if (!data.key) {
-		warn("Could not read host key from SSH host\n");
-		exit(1);
-	}
+	assert(data.key, "Could not read host key from SSH host");
 
 	args.key = data.key;
 }
@@ -297,34 +298,24 @@ while (substr(ARGV[0], 0, 1) == "-") {
 		exit(usage());
 }
 
-if (command == "add-host" || command == "set-host" ||
-    command == "add-ssh-host" || command == "set-ssh-host") {
+if (command in [ "add-host", "set-host", "add-ssh-host", "set-ssh-host" ]) {
 	hostname = shift(ARGV);
-	if (!hostname) {
-		warn("Missing host name argument\n");
-		exit(1);
-	}
+	assert(hostname, "Missing host name argument");
 }
 
-if (command == "add-ssh-host" || command == "set-ssh-host") {
+if (command in [ "add-ssh-host", "set-ssh-host" ]) {
 	ssh_host = shift(ARGV);
-	if (!ssh_host) {
-		warn("Missing SSH host/user argument\n");
-		exit(1);
-	}
+	assert(ssh_host, "Missing SSH host/user argument");
 }
 
-if (command == "add-service" || command == "set-service") {
+if (command in [ "add-service", "set-service" ]) {
 	servicename = shift(ARGV);
-	if (!servicename) {
-		warn("Missing service name argument\n");
-		exit(1);
-	}
+	assert(servicename, "Missing service name argument");
 }
 
 fetch_args();
 
-if (command == "add-ssh-host" || command == "set-ssh-host") {
+if (command in [ "add-ssh-host", "set-ssh-host" ]) {
 	sync_ssh_host(ssh_host);
 	command = replace(command, "ssh-", "");
 }
@@ -337,35 +328,32 @@ if (command == "create") {
 	};
 } else {
 	fh = fs.open(file);
-	if (!fh) {
-		warn("Could not open input file ", file, "\n");
-		exit(1);
-	}
+	assert(fh, `Could not open input file ${file}`);
+
 	try {
 		net_data = json(fh);
 	} catch(e) {
-		warn("Could not parse input file ", file, "\n");
-		exit(1);
+		assert(false, `Could not parse input file ${file}`);
 	}
 }
 
 if (command == "create") {
-	for (key in keys(defaults))
-		args[key] ??= "" + defaults[key];
-	if (!fs.access(file + ".key"))
-		system(unet_tool + " -G > " + file + ".key");
+	for (key, val in defaults)
+		args[key] ??= `${val}`;
+	if (!fs.access(`${file}.key`))
+		system(`${unet_tool} -G > ${file}.key`);
 }
 
 if (command == "sign") {
-	ret = system(unet_tool + " -S -K " + file + ".key -o " + file + ".bin " + file);
+	ret = system(`${unet_tool} -S -K ${file}.key -o ${file}.bin ${file}`);
 	if (ret != 0)
 		exit(ret);
 
 	if (args.upload) {
 		hosts = split(args.upload, ",");
 		for (host in hosts) {
-			warn("Uploading " + file + ".bin to " + host + "\n");
-			ret = system(unet_tool + " -U " + host + " -K "+ file + ".key " + file + ".bin");
+			warn(`Uploading ${file}.bin to ${host}\n`);
+			ret = system(`${unet_tool} -U ${host} -K ${file}.key ${file}.bin`);
 			if (ret)
 				warn("Upload failed\n");
 		}
@@ -373,44 +361,43 @@ if (command == "sign") {
 	exit(0);
 }
 
-if (command == "create" || command == "set-config") {
+switch (command) {
+case 'create':
+case 'set-config':
 	set_fields(net_data.config, {
 		port: "int",
 		keepalive: "int",
 	});
 	set_field("int", net_data.config, "peer-exchange-port", args.pex_port);
-} else if (command == "add-host") {
+	break;
+
+case 'add-host':
 	net_data.hosts[hostname] = {};
-	if (!args.key) {
-		warn("Missing host key\n");
-		exit(1);
-	}
+	assert(args.key, "Missing host key");
 	set_host(hostname);
-} else if (command == "set-host") {
-	if (!net_data.hosts[hostname]) {
-		warn("Host '", hostname, "' does not exist\n");
-		exit(1);
-	}
+	break;
+
+case 'set-host':
+	assert(net_data.hosts[hostname], `Host '${hostname}' does not exist`);
 	set_host(hostname);
-} else if (command == "add-service") {
+	break;
+
+case 'add-service':
 	net_data.services[servicename] = {
 		config: {},
 		members: [],
 	};
-	if (!args.type) {
-		warn("Missing service type\n");
-		exit(1);
-	}
+	assert(args.type, "Missing service type");
 	set_service(servicename);
-} else if (command == "set-service") {
-	if (!net_data.services[servicename]) {
-		warn("Service '", servicename, "' does not exist\n");
-		exit(1);
-	}
+	break;
+
+case 'set-service':
+	assert(net_data.services[servicename], `Service '${servicename}' does not exist`);
 	set_service(servicename);
-} else {
-	warn("Unknown command\n");
-	exit(1);
+	break;
+
+default:
+	assert(false, "Unknown command");
 }
 
 net_data_json = sprintf("%.J\n", net_data);

--- a/scripts/unet-cli
+++ b/scripts/unet-cli
@@ -1,5 +1,7 @@
 #!/usr/bin/env ucode
 
+'use strict';
+
 import { access, basename, dirname, mkstemp, open, writefile } from 'fs';
 
 function assert(cond, message) {
@@ -11,17 +13,17 @@ function assert(cond, message) {
 	return true;
 }
 
+let unet_tool = "unet-tool";
 let script_dir = sourcepath(0, true);
+
 if (basename(script_dir) == "scripts") {
 	unet_tool = `${dirname(script_dir)}/unet-tool`;
 	assert(access(unet_tool, "x"), "unet-tool missing");
-} else {
-	unet_tool = "unet-tool";
 }
 
-args = {};
+let args = {};
 
-defaults = {
+const defaults = {
 	port: 51830,
 	pex_port: 51831,
 	keepalive: 10,
@@ -86,10 +88,10 @@ function usage() {
 if (length(ARGV) < 2)
 	exit(usage());
 
-file = shift(ARGV);
-command = shift(ARGV);
+let file = shift(ARGV);
+let command = shift(ARGV);
 
-field_types = {
+const field_types = {
 	int: function(object, name, val) {
 		object[name] = int(val);
 	},
@@ -121,7 +123,7 @@ field_types = {
 	},
 };
 
-service_field_types = {
+const service_field_types = {
 	vxlan: {
 		id: "int",
 		port: "int",
@@ -130,7 +132,7 @@ service_field_types = {
 	},
 };
 
-ssh_script = `
+const ssh_script = `
 
 set_list() {
 	local field="$1"
@@ -180,12 +182,11 @@ reload_config
 ifup $INTERFACE
 `;
 
-args = {};
-print_only = false;
+let print_only = false;
 
 function fetch_args() {
-	for (arg in ARGV) {
-		vals = match(arg, /^(.[[:alnum:]_-]*)=(.*)$/);
+	for (let arg in ARGV) {
+		let vals = match(arg, /^(.[[:alnum:]_-]*)=(.*)$/);
 		assert(vals, `Invalid argument: ${arg}`);
 		args[vals[1]] = vals[2]
 	}
@@ -209,7 +210,7 @@ function set_field(typename, object, name, val) {
 }
 
 function set_fields(object, list) {
-	for (f in list)
+	for (let f in list)
 		set_field(list[f], object, f, args[f]);
 }
 
@@ -269,11 +270,11 @@ function sync_ssh_host(host) {
 	fh.flush();
 	fh.seek();
 
-	fh2 = mkstemp();
+	let fh2 = mkstemp();
 	system(`ssh ${host} sh <&${fh.fileno()} >&${fh2.fileno()}`);
 	fh.close();
 
-	data = {};
+	let data = {}, line;
 
 	fh2.seek();
 	while (line = fh2.read("line")) {
@@ -289,7 +290,7 @@ function sync_ssh_host(host) {
 }
 
 while (substr(ARGV[0], 0, 1) == "-") {
-	opt = shift(ARGV);
+	let opt = shift(ARGV);
 	if (opt == "--")
 		break;
 	else if (opt == "-p")
@@ -297,6 +298,8 @@ while (substr(ARGV[0], 0, 1) == "-") {
 	else
 		exit(usage());
 }
+
+let hostname, ssh_host, servicename;
 
 if (command in [ "add-host", "set-host", "add-ssh-host", "set-ssh-host" ]) {
 	hostname = shift(ARGV);
@@ -320,6 +323,8 @@ if (command in [ "add-ssh-host", "set-ssh-host" ]) {
 	command = replace(command, "ssh-", "");
 }
 
+let net_data;
+
 if (command == "create") {
 	net_data = {
 		config: {},
@@ -327,7 +332,7 @@ if (command == "create") {
 		services: {}
 	};
 } else {
-	fh = open(file);
+	let fh = open(file);
 	assert(fh, `Could not open input file ${file}`);
 
 	try {
@@ -338,20 +343,19 @@ if (command == "create") {
 }
 
 if (command == "create") {
-	for (key, val in defaults)
+	for (let key, val in defaults)
 		args[key] ??= `${val}`;
 	if (!access(`${file}.key`))
 		system(`${unet_tool} -G > ${file}.key`);
 }
 
 if (command == "sign") {
-	ret = system(`${unet_tool} -S -K ${file}.key -o ${file}.bin ${file}`);
+	let ret = system(`${unet_tool} -S -K ${file}.key -o ${file}.bin ${file}`);
 	if (ret != 0)
 		exit(ret);
 
 	if (args.upload) {
-		hosts = split(args.upload, ",");
-		for (host in hosts) {
+		for (let host in split(args.upload, ",")) {
 			warn(`Uploading ${file}.bin to ${host}\n`);
 			ret = system(`${unet_tool} -U ${host} -K ${file}.key ${file}.bin`);
 			if (ret)
@@ -400,7 +404,8 @@ default:
 	assert(false, "Unknown command");
 }
 
-net_data_json = sprintf("%.J\n", net_data);
+const net_data_json = sprintf("%.J\n", net_data);
+
 if (print_only)
 	print(net_data_json);
 else


### PR DESCRIPTION
This PR applies a series of cleanup commits to the `unet-cli` script:

  - The first commit introduces modern syntax elements and somewhat reduces redundant code by encapsulating argument checking into a custom `assert()` function, using `switch` statements instead of `if/else` ladders, `in` lookups instead of or-chained equal statements and template strings with variable interpolation instead of explicit or implicit string concatenation 
  - The second commit uses ES6 style module imports to selectively load `fs` module functions into the program (requires current ucode)
  - The third commit enables strict mode and explicitly declares all variables used by the script